### PR TITLE
chore: tune vercel deployment config

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "*.{js,css,md}": "prettier --write"
   },
   "engines": {
-    "node": ">=22"
+    "node": "22.x"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,6 @@
   },
   "functions": {
     "api/*.js": {
-      "memory": 128,
       "maxDuration": 10
     }
   },


### PR DESCRIPTION
## Summary
- pin the runtime to Node 22.x so Vercel no longer warns about automatic upgrades
- drop the unused `memory` override in `vercel.json` which Vercel ignores under Active CPU billing

## Testing
- npm test